### PR TITLE
feat(api): add get my reports endpoint and translate error messages

### DIFF
--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -25,7 +25,7 @@ class CommentController {
           .status(401)
           .json({
             status: "error",
-            message: "Unauthorized: User info missing in token",
+            message: "No autorizado: Falta información del usuario en el token",
           });
       }
 

--- a/src/controllers/report.controller.ts
+++ b/src/controllers/report.controller.ts
@@ -32,7 +32,7 @@ class ReportController {
     try {
       const validated = createReportSchema.parse(req.body);
       const userId = req.user?.id_user;
-      if (!userId) throw new Error("User not authenticated");
+      if (!userId) throw new Error("Usuario no autenticado");
 
       const newReport = await reportService.createReport({
         ...validated,
@@ -49,7 +49,7 @@ class ReportController {
       const { id } = idParamSchema.parse(req.params);
       const validated = updateReportStatusSchema.parse(req.body);
       const authorityId = req.user?.id_user;
-      if (!authorityId) throw new Error("User not authenticated");
+      if (!authorityId) throw new Error("Usuario no autenticado");
 
       const result = await reportService.updateReportStatus(
         id,
@@ -57,6 +57,20 @@ class ReportController {
         authorityId,
       );
       res.status(200).json({ status: "success", data: result });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getMyReports(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.user?.id_user;
+      if (!userId) {
+        return res.status(401).json({ status: "error", message: "No autorizado: Falta el token" });
+      }
+
+      const reports = await reportService.getReportsByUser(userId);
+      res.status(200).json({ status: "success", data: reports });
     } catch (error) {
       next(error);
     }

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -25,7 +25,7 @@ export const authenticateToken = (
   if (!token) {
     return res
       .status(401)
-      .json({ status: "error", message: "Unauthorized: Token missing" });
+      .json({ status: "error", message: "No autorizado: Falta el token" });
   }
 
   const secret =
@@ -37,7 +37,7 @@ export const authenticateToken = (
         .status(403)
         .json({
           status: "error",
-          message: "Forbidden: Invalid or expired token",
+          message: "Prohibido: Token inválido o expirado",
         });
     }
 

--- a/src/middlewares/role.middleware.ts
+++ b/src/middlewares/role.middleware.ts
@@ -5,14 +5,14 @@ export const authorizeRoles = (...allowedRoles: string[]) => {
     if (!req.user) {
       return res.status(401).json({
         status: "error",
-        message: "Unauthorized: User not authenticated",
+        message: "No autorizado: Usuario no autenticado",
       });
     }
 
     if (!allowedRoles.includes(req.user.role)) {
       return res.status(403).json({
         status: "error",
-        message: `Forbidden: This resource requires one of the following roles: ${allowedRoles.join(", ")}`,
+        message: `Prohibido: Este recurso requiere uno de los siguientes roles: ${allowedRoles.join(", ")}`,
       });
     }
 

--- a/src/repositories/report.repository.ts
+++ b/src/repositories/report.repository.ts
@@ -50,6 +50,17 @@ class ReportRepository {
       },
     });
   }
+
+  async findByUserId(userId: number) {
+    return await prisma.report.findMany({
+      where: { id_user: userId },
+      include: {
+        type: true,
+        status: true,
+      },
+      orderBy: { date: "desc" },
+    });
+  }
 }
 
 export const reportRepository = new ReportRepository();

--- a/src/routes/report.routes.ts
+++ b/src/routes/report.routes.ts
@@ -13,6 +13,7 @@ router.get(
   authorizeRoles("Autoridad"),
   reportController.getAll,
 );
+router.get("/reports/me", authenticateToken, reportController.getMyReports);
 router.get("/reports/:id", reportController.getOne);
 router.post("/reports", authenticateToken, reportController.create);
 router.patch(

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -12,7 +12,7 @@ class AuthService {
     const citizenRoleObj = roles.find((r) => r.type_role === "Ciudadano");
 
     if (!citizenRoleObj) {
-      throw new Error("Default role 'Ciudadano' not found in database");
+      throw new Error("Rol por defecto 'Ciudadano' no encontrado");
     }
 
     return await userService.createUser({
@@ -24,12 +24,12 @@ class AuthService {
   async login(data: LoginInput) {
     const user = await userRepository.getByEmail(data.email);
     if (!user) {
-      throw new Error("Invalid credentials");
+      throw new Error("Credenciales inválidas");
     }
 
     const isPasswordValid = await bcrypt.compare(data.password, user.password);
     if (!isPasswordValid) {
-      throw new Error("Invalid credentials");
+      throw new Error("Credenciales inválidas");
     }
 
     const secret =

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -5,7 +5,7 @@ import type { CreateCommentInput } from "../schemas/comment.schema.js";
 class CommentService {
   async addComment(id_report: number, data: CreateCommentInput & { id_user: number }) {
     const report = await reportRepository.findById(id_report);
-    if (!report) throw new Error("Report not found");
+    if (!report) throw new Error("Denuncia no encontrada");
 
     return await commentRepository.create({
       id_report,
@@ -16,7 +16,7 @@ class CommentService {
 
   async getCommentsByReport(id_report: number) {
     const report = await reportRepository.findById(id_report);
-    if (!report) throw new Error("Report not found");
+    if (!report) throw new Error("Denuncia no encontrada");
 
     return await commentRepository.findByReportId(id_report);
   }

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -17,7 +17,7 @@ class ReportService {
 
   async getReportById(id: number) {
     const report = await reportRepository.findById(id);
-    if (!report) throw new Error("Report not found");
+    if (!report) throw new Error("Denuncia no encontrada");
     return report;
   }
 
@@ -28,7 +28,7 @@ class ReportService {
       where: { type_status: "Pendiente" },
     });
     if (!pendingStatus)
-      throw new Error("Default status 'Pendiente' not found in database");
+      throw new Error("Estado por defecto 'Pendiente' no encontrado");
 
     const { id_type, id_user, ...rest } = data;
 
@@ -47,12 +47,12 @@ class ReportService {
     authorityId: number,
   ) {
     const report = await reportRepository.findById(id);
-    if (!report) throw new Error("Report not found");
+    if (!report) throw new Error("Denuncia no encontrada");
 
     const statusObj = await prisma.status.findUnique({
       where: { id_status: data.id_status },
     });
-    if (!statusObj) throw new Error("Status not found");
+    if (!statusObj) throw new Error("Estado no encontrado");
 
     const updatedReport = await reportRepository.updateStatus(
       id,
@@ -85,6 +85,10 @@ class ReportService {
       result += chars.charAt(Math.floor(Math.random() * chars.length));
     }
     return result;
+  }
+
+  async getReportsByUser(userId: number) {
+    return await reportRepository.findByUserId(userId);
   }
 }
 

--- a/src/services/role.service.ts
+++ b/src/services/role.service.ts
@@ -8,7 +8,7 @@ class RoleService {
   async getRoleById(id: number) {
     const role = await roleRepository.getById(id);
     if (!role) {
-      throw new Error("Role not found");
+      throw new Error("Rol no encontrado");
     }
     return role;
   }
@@ -16,7 +16,7 @@ class RoleService {
   async createRole(type_role: string) {
     const existing = await roleRepository.getByType(type_role);
     if (existing) {
-      throw new Error("Role type already exists");
+      throw new Error("El tipo de rol ya existe");
     }
     return await roleRepository.create({ type_role });
   }

--- a/src/services/status.service.ts
+++ b/src/services/status.service.ts
@@ -8,7 +8,7 @@ class StatusService {
   async getStatusById(id: number) {
     const status = await statusRepository.getById(id);
     if (!status) {
-      throw new Error("Status not found");
+      throw new Error("Estado no encontrado");
     }
     return status;
   }
@@ -16,7 +16,7 @@ class StatusService {
   async createStatus(type_status: string) {
     const existing = await statusRepository.getByType(type_status);
     if (existing) {
-      throw new Error("Status type already exists");
+      throw new Error("El tipo de estado ya existe");
     }
     return await statusRepository.create({ type_status });
   }

--- a/src/services/type.service.ts
+++ b/src/services/type.service.ts
@@ -8,7 +8,7 @@ class TypeService {
   async getTypeById(id: number) {
     const type = await typeRepository.getById(id);
     if (!type) {
-      throw new Error("Type not found");
+      throw new Error("Tipo de denuncia no encontrado");
     }
     return type;
   }
@@ -16,7 +16,7 @@ class TypeService {
   async createType(type: string) {
     const existing = await typeRepository.getByType(type);
     if (existing) {
-      throw new Error("Type already exists");
+      throw new Error("El tipo de denuncia ya existe");
     }
     return await typeRepository.create({ type });
   }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -13,7 +13,7 @@ class UserService {
   async getUserById(id: number) {
     const user = await userRepository.getById(id);
     if (!user) {
-      throw new Error("User not found");
+      throw new Error("Usuario no encontrado");
     }
     return UserMapper.toSanitizedUser(user);
   }
@@ -21,17 +21,17 @@ class UserService {
   async createUser(data: CreateUserInput & { id_role: number }) {
     const existingDni = await userRepository.getByDni(data.dni);
     if (existingDni) {
-      throw new Error("DNI already exists");
+      throw new Error("El DNI ya está registrado");
     }
 
     const existingEmail = await userRepository.getByEmail(data.email);
     if (existingEmail) {
-      throw new Error("Email already exists");
+      throw new Error("El correo electrónico ya está registrado");
     }
 
     const role = await roleRepository.getById(data.id_role);
     if (!role) {
-      throw new Error("Provided role does not exist");
+      throw new Error("El rol proporcionado no existe");
     }
 
     const hashedPassword = await bcrypt.hash(data.password, 10);
@@ -46,21 +46,21 @@ class UserService {
 
   async updateUser(id: number, data: UpdateUserInput) {
     const existingUser = await userRepository.getById(id);
-    if (!existingUser) throw new Error("User not found");
+    if (!existingUser) throw new Error("Usuario no encontrado");
 
     if (data.dni && data.dni !== existingUser.dni) {
       const duplicateDni = await userRepository.getByDni(data.dni);
-      if (duplicateDni) throw new Error("DNI already exists");
+      if (duplicateDni) throw new Error("El DNI ya está registrado");
     }
 
     if (data.email && data.email !== existingUser.email) {
       const duplicateEmail = await userRepository.getByEmail(data.email);
-      if (duplicateEmail) throw new Error("Email already exists");
+      if (duplicateEmail) throw new Error("El correo electrónico ya está registrado");
     }
 
     if (data.id_role) {
       const role = await roleRepository.getById(data.id_role);
-      if (!role) throw new Error("Provided role does not exist");
+      if (!role) throw new Error("El rol proporcionado no existe");
     }
 
     if (data.password) {


### PR DESCRIPTION
- Added findByUserId in report.repository.ts and getReportsByUser in report.service.ts to fetch user's reports.

- Created getMyReports in report.controller.ts protected by authentication.

- Registered GET /api/v1/reports/me in report.routes.ts.

- Translated all API error messages across services, controllers, and middlewares from English to Spanish to ensure consistent client-side UX.